### PR TITLE
Added to explain where to find the DMESG output.

### DIFF
--- a/docs/dmesg.md
+++ b/docs/dmesg.md
@@ -6,7 +6,7 @@ log is a high-level function used to print your own messages.
 
 ## DMESG LOGGING
 # In The Browser
-To find the output of the DMESG debugging tool, open your browser's 
+To find the output of the DMESG debugging tool, open your browser's  
 developer tool (F12 in most browsers), then click the console tab, and finally run your program in the simulator.
 The function does not belong to only one PXT target, it exists in all PXT targets.
 # In Hardware


### PR DESCRIPTION
> ## Recommendation for Triage
> **This issue might be better filed in a different repository.**
> 
> **Correct Repository**: microsoft/pxt (pxt-core)
> 
> **Reasoning**: The `control.dmesg()` function is a core framework debugging feature implemented in the pxt-core simulator runtime (`pxsim/runtime.ts`), not an Arcade-specific feature. While it can be used in Arcade projects, questions about core debugging APIs and their behavior are better suited for the pxt repository where the implementation and documentation live.
> 
> However, since this affects all PXT targets including Arcade, it's also appropriate to answer here.
> 
> ## Answer to Your Question
> **Where does `control.dmesg()` log on PXT targets?**
> 
> **In the Simulator (Browser)**:
> 
> * `control.dmesg(s)` outputs to `pxsim.log()` which writes to the **browser's developer console**
> * Implementation: `dmesg: (s: string) => pxsim.log("DMESG: " + s)` in `pxsim/runtime.ts`
> * To see output: Open your browser's developer tools (F12 in most browsers) → Console tab → Run your program in the simulator
> 
> **On Physical Hardware**:
> 
> * On hardware devices (Arcade cabinets, micro:bit, etc.), `dmesg()` typically outputs to the device's serial/UART interface
> * You can view this with a serial monitor connected to the device's debug connector
> * The exact behavior depends on the hardware platform (SAMD, STM32, RP2040, etc.)
> 
> **Related Functions**:
> 
> * `control.dmesgPtr(str, ptr)` - Logs a message with a pointer/object reference
> * `control.dmesgValue(v)` - Dumps internal information about a value
> * `control.__log(priority, text)` - Similar logging with priority levels
> 
> **Likely fix location**: microsoft/pxt/pxtsim/runtime.ts (simulator implementation) and libs/base/sim/control.ts in pxt-common-packages
> 
> Recommendations for Assignee
> ### Analysis
> This is a documentation/knowledge question rather than a bug or feature request. The user is trying to understand where diagnostic logging output appears when using PXT's debugging functions. The answer is straightforward: browser console for simulator, serial output for hardware. This could benefit from better documentation in the API reference.
> 
> ### Duplicate & Related Issues
> **Duplicates**:
> 
> * No duplicates found
> 
> **Related Issues**:
> 
> * [Console simulator should stop when the simulator is stopped #1955](https://github.com/microsoft/pxt-arcade/issues/1955) (closed) - About Console.Log() simulator behavior, related to logging but different API
> 
> ### Location Hints
> Implementation files:
> 
> * **microsoft/pxt** - `pxsim/runtime.ts` (line ~234) - Simulator implementation of `dmesg()`
> * **microsoft/pxt-arcade** - `libs/core/shims.d.ts` (lines 243-249) - TypeScript definitions for `dmesg()` functions
> * **microsoft/pxt-common-packages** - `libs/base/sim/control.ts` - Simulator control functions
> 
> ### Next Steps
> **Copilot Coding Agent Assessment**: ❌ No, human needed
> 
> **Reasoning**: This is a documentation/knowledge question that has been answered. No code changes are needed unless the team decides to improve the API documentation or add in-editor hints about where dmesg output appears. A human should review whether to close this as answered or convert it to a documentation enhancement request.
> 
> > AI generated by [Triage](https://github.com/microsoft/pxt-arcade/actions/runs/23268609332)


**Is your feature request related to a problem? Please describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you'd like**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

Solved where to find it here.