### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag-bump-commit.yml
+++ b/.github/workflows/tag-bump-commit.yml
@@ -1,6 +1,8 @@
 # ref from pxt-arcade/.github/tag-bump-commit.yml
 
 name: Tag version on merged bump commit
+permissions:
+  contents: read
 
 on:
   workflow_call:
@@ -17,6 +19,7 @@ jobs:
     needs: check-merge
     runs-on: ubuntu-latest
     if: always()
+    permissions: {}
     steps:
       - name: check-merge outputs
         run: |
@@ -27,6 +30,8 @@ jobs:
     needs: check-merge
     if: fromJSON(needs.check-merge.outputs.is_merged_pr || 'false') == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       did_tag: ${{ steps.tag-op.outputs.did_tag }}
       tag: ${{ steps.tag-op.outputs.tag }}
@@ -77,6 +82,7 @@ jobs:
     needs: check-merge
     if: fromJSON(needs.check-merge.outputs.is_merged_pr || 'false') == false
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       did_tag: false
     steps:
@@ -86,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tag-version, not-tag-version]
     if: always()
+    permissions: {}
     outputs:
       did_tag: ${{ needs.tag-version.outputs.did_tag || false }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/8](https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/8)

In general, the fix is to add an explicit `permissions` block to the workflow, applying least-privilege. Since only the `tag-version` job performs repository write operations (creating and pushing git tags), that job should be granted `contents: write`, while other jobs should have more restrictive permissions, ideally `contents: read` or `permissions: {}` if they don’t need the token.

The safest, minimal-impact change is:
- Add a root-level `permissions: contents: read` so that, by default, jobs only get read access.
- Override permissions for `tag-version` with `permissions: contents: write` so it can create and push tags.
- Optionally (but beneficial for least privilege), restrict jobs like `return` and others that don’t need the token with `permissions: {}` to disable `GITHUB_TOKEN` entirely there. This is fully backward compatible because those jobs were not using the token.

Concretely in `.github/workflows/tag-bump-commit.yml`:
- Insert a root `permissions:` block after the `name:` line.
- Add a `permissions:` block under the `tag-version:` job granting `contents: write`.
- Optionally add `permissions: {}` under `check-merge-outputs:`, `not-tag-version:`, and `return:` to make explicit that they don’t use the token. This does not change existing functionality since those jobs only run shell `echo` commands.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
