### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jsonBot.yml
+++ b/.github/workflows/jsonBot.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-file-list:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest 
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/3](https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/3)

In general, to fix this, add an explicit `permissions` block to the workflow or to the specific job so that the `GITHUB_TOKEN` does not inherit broad default permissions. The block should grant only the scopes necessary for the steps in this job.

For this workflow, the job needs to: (1) check out the repository (reads contents) and (2) commit and push changes (writes contents). It does not interact with issues, pull requests, workflows, or other resources. Therefore, we can safely set `permissions: contents: write` for this job. The best minimal change is to add a `permissions` entry under `jobs.build-file-list` (just above `runs-on`) in `.github/workflows/jsonBot.yml`. No imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
