### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/is-vtag.yml
+++ b/.github/workflows/is-vtag.yml
@@ -7,6 +7,9 @@ on:
         description: 'Whether the tag is a semver tag'
         value: ${{ jobs.filter-vtags.outputs.is_vtag }}
 
+permissions:
+  contents: read
+
 jobs:
   filter-vtags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/2](https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required access for this workflow. Since this job only inspects `GITHUB_REF_TYPE` and `GITHUB_REF_NAME` and writes to `GITHUB_OUTPUT`, and does not interact with the repository via the `GITHUB_TOKEN`, we can safely restrict the token to read-only contents, which is the minimal commonly recommended baseline.

The best way to fix this specific file without changing existing functionality is to add a `permissions:` section at the workflow root (alongside `on:` and `jobs:`). This will apply to all jobs that do not define their own permissions. Given the current usage, `contents: read` is sufficient and conservative. Concretely, in `.github/workflows/is-vtag.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (e.g., after line 8 or line 9 in the current snippet). No imports, methods, or further definitions are required since this is purely declarative GitHub Actions configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
