### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-if-merged-pr.yml
+++ b/.github/workflows/check-if-merged-pr.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   check-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       is_merged_pr: ${{ steps.parse-check-pr.outputs.is_merged_pr }}
       pr_head_sha: ${{ steps.parse-check-pr.outputs.pr_head_sha }}


### PR DESCRIPTION
Potential fix for [https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/1](https://github.com/DeveloperTryingToCodeLikeOtherOfThem/pxt-hardware-programming-docs/security/code-scanning/1)

In general, fix this by adding a `permissions:` block that grants only the scopes needed by the job. Because this workflow only reads pull request and commit information via the GitHub API and does not write anything back, it can safely use read-only access to repository contents and pull requests.

The best fix is to add a `permissions` block to the `check-pr` job so its `GITHUB_TOKEN` is restricted, without affecting other workflows. The GitHub REST API call `repos.listPullRequestsAssociatedWithCommit` requires read access to repository contents and PR metadata; the minimal practical set here is `contents: read` and `pull-requests: read`. Concretely, in `.github/workflows/check-if-merged-pr.yml`, under `jobs:`, in the `check-pr:` job definition just below `runs-on: ubuntu-latest`, insert:

```yaml
    permissions:
      contents: read
      pull-requests: read
```

No additional imports, methods, or definitions are needed, as this only changes the workflow metadata.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
